### PR TITLE
Refactor rate limiting and session management

### DIFF
--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,8 +1,13 @@
 import { ipKeyGenerator, rateLimit } from "express-rate-limit";
+import {
+  MCP_RATE_LIMIT_MAX,
+  OAUTH_RATE_LIMIT_MAX,
+  RATE_LIMIT_WINDOW_MS,
+} from "../shared/constants";
 
 export const userRateLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 60,
+  windowMs: RATE_LIMIT_WINDOW_MS,
+  max: MCP_RATE_LIMIT_MAX,
   keyGenerator: (req) => {
     if (req.userId) {
       return req.userId;
@@ -11,15 +16,15 @@ export const userRateLimiter = rateLimit({
   },
   message: {
     error: "rate_limit_exceeded",
-    error_description: "Too many requests. Limit: 60 requests per minute.",
+    error_description: `Too many requests. Limit: ${MCP_RATE_LIMIT_MAX} requests per minute.`,
   },
   standardHeaders: true,
   legacyHeaders: false,
 });
 
 export const oauthRateLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 10,
+  windowMs: RATE_LIMIT_WINDOW_MS,
+  max: OAUTH_RATE_LIMIT_MAX,
   keyGenerator: (req) => ipKeyGenerator(req.ip ?? "unknown"),
   message: {
     error: "rate_limit_exceeded",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -8,7 +8,15 @@ export const MCP_SERVER_DEFAULT_SCOPE = "fathom:read";
 export const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
 export const SESSION_CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
 export const STALE_SESSION_CUTOFF_MS = 24 * 60 * 60 * 1000;
+export const IDLE_TRANSPORT_TTL_MS = 5 * 60 * 1000;
+export const IDLE_TRANSPORT_REAP_INTERVAL_MS = 60 * 1000;
+export const MAX_ACTIVE_TRANSPORTS_WARN = 100;
 export const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 10 * 1000;
+
+// Rate Limiting
+export const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+export const MCP_RATE_LIMIT_MAX = 200;
+export const OAUTH_RATE_LIMIT_MAX = 10;
 
 // Fathom API
 export const FATHOM_API_TIMEOUT_MS = 30 * 1000;


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Other (describe below)

## Description

Fixes an in-memory session transport leak where 96% of MCP sessions were never cleaned up from the `activeTransports` Map. When Claude drops SSE connections, `transport.onclose` fires unreliably (~4% of the time), causing the Map to grow unboundedly (observed: 51 to 171 in 75 minutes). This also triggered 429 rate limit cascades because the tight 60 req/min limit couldn't handle Claude's bursty session creation pattern (~7 requests per session).

**Changes:**
- **Idle transport reaper** -- New `reapIdleTransports()` method runs every 60s, closing and removing any transport idle for >5 minutes. This is the core fix for the memory leak.
- **Rate limit raised to 200/min** -- Gives 3x headroom over Claude's observed burst rate (~63 req/min). Extracted all rate limit magic numbers to `constants.ts`.
- **Soft cap warning** -- Logs a warning when `activeCount` exceeds 100, providing early visibility before memory becomes an issue.

## Testing

**Manual testing notes:**
- All 181 tests pass across 14 test files
- 4 new tests added for idle transport reaper covering: reaping idle transports, preserving active transports, no-op on empty map, graceful handling of close errors
- Existing scheduler tests updated to verify both intervals (hourly DB cleanup + 60s reaper) start and stop correctly