### PR TITLE
Enhance pagination descriptions in API documentation and server tool …

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -48,7 +48,7 @@ List meetings with optional filters including date range, team, and recorder.
 | calendar_invitees_domains_type | enum | No | "all", "only_internal", or "one_or_more_external" |
 | created_after | ISO datetime | No | Only meetings created after this date |
 | created_before | ISO datetime | No | Only meetings created before this date |
-| cursor | string | No | Pagination cursor for next page |
+| cursor | string | No | Pagination: pass the next_cursor from the previous response to get the next page |
 | include_action_items | boolean | No | Include action items in response |
 | include_crm_matches | boolean | No | Include CRM matches in response |
 | recorded_by | string[] | No | Filter by recorder email addresses |
@@ -98,6 +98,8 @@ List meetings with optional filters including date range, team, and recorder.
 }
 ```
 
+**Pagination:** When `next_cursor` is non-null, call list_meetings again with `cursor` set to that value to fetch more meetings.
+
 **Example Usage:**
 
 ```
@@ -120,7 +122,7 @@ Search meetings by title. This is an MCP-native tool that performs client-side f
 | calendar_invitees_domains_type | enum | No | "all", "only_internal", or "one_or_more_external" |
 | created_after | ISO datetime | No | Only meetings created after this date |
 | created_before | ISO datetime | No | Only meetings created before this date |
-| cursor | string | No | Pagination cursor |
+| cursor | string | No | Pagination: pass next_cursor from the previous response to get the next page |
 | include_action_items | boolean | No | Include action items |
 | include_crm_matches | boolean | No | Include CRM matches |
 | recorded_by | string[] | No | Filter by recorder emails |
@@ -128,7 +130,7 @@ Search meetings by title. This is an MCP-native tool that performs client-side f
 
 **Response Schema:**
 
-Same as list_meetings, but filtered to only include meetings where the title or meeting_title contains the query string (case-insensitive).
+Same as list_meetings, but filtered to only include meetings where the title or meeting_title contains the query string (case-insensitive). When `next_cursor` is non-null, call search_meetings again with the same query and filters and `cursor` set to that value to search more pages.
 
 **Performance Note:**
 

--- a/src/tools/server.ts
+++ b/src/tools/server.ts
@@ -60,10 +60,11 @@ export function createToolServer(
     {
       title: "List Meetings",
       description:
-        "List Fathom meetings with optional filters: cursor (pagination), " +
+        "List Fathom meetings with optional filters: cursor (pagination; pass the next_cursor from the previous response to get the next page), " +
         "created_after, created_before (ISO timestamps), calendar_invitees_domains (company domains), " +
         "calendar_invitees_domains_type (all/only_internal/one_or_more_external), " +
-        "teams (team names), recorded_by (recorder emails), include_action_items (boolean), include_crm_matches (boolean)",
+        "teams (team names), recorded_by (recorder emails), include_action_items (boolean), include_crm_matches (boolean). " +
+        "Response includes next_cursor: when non-null, call again with cursor set to that value to fetch more meetings.",
       inputSchema: listMeetingsReqSchema.shape,
       annotations: { readOnlyHint: true },
     },
@@ -79,9 +80,10 @@ export function createToolServer(
       title: "Search Meetings",
       description:
         "Search Fathom meetings by title or meeting_title. Required: query (search term). " +
-        "Optional filters: cursor (pagination), created_after, created_before (ISO timestamps), " +
-        "calendar_invitees_domains, calendar_invitees_domains_type, teams, recorded_by, " +
-        "include_action_items (boolean), include_crm_matches (boolean)",
+        "Optional filters: cursor (pagination; pass next_cursor from the previous response to get the next page), " +
+        "created_after, created_before (ISO timestamps), calendar_invitees_domains, calendar_invitees_domains_type, " +
+        "teams, recorded_by, include_action_items (boolean), include_crm_matches (boolean). " +
+        "Response includes next_cursor: when non-null, call again with cursor set to that value to search more meetings.",
       inputSchema: searchMeetingsReqSchema.shape,
       annotations: { readOnlyHint: true },
     },


### PR DESCRIPTION
## Summary

Tool descriptions and docs now tell the model to paginate when more results exist. For **list_meetings** and **search_meetings**, the description states that when the response includes a non-null `next_cursor`, the client should call the tool again with `cursor` set to that value to fetch the next page. This addresses cases where search/list returned no results because matches were on later pages and the model never paginated.

**Changes:**
- **`src/tools/server.ts`**: Updated `list_meetings` and `search_meetings` tool descriptions to explain that `cursor` is for pagination (pass `next_cursor` from the previous response) and that a non-null `next_cursor` means the client should call again with that `cursor`.
- **`public/llms-full.txt`**: Clarified the `cursor` parameter and added explicit **Pagination** guidance for both tools (when `next_cursor` is non-null, call again with `cursor` set to that value).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [x] Documentation
- [ ] Other (describe below)

## Testing

**Video walkthrough (Loom, etc.):**
<!-- Paste link here -->

**Screenshots:**
<!-- Drag and drop images here -->

**Manual testing notes:**
- Confirmed tool descriptions in `server.ts` include the new pagination wording.
- Confirmed `public/llms-full.txt` has updated cursor descriptions and the new Pagination notes for list_meetings and search_meetings.
- No code behavior change; only descriptions and docs.

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->