### PR TITLE
Add SSE support with new routes and session management

### DIFF
--- a/server.json
+++ b/server.json
@@ -12,6 +12,10 @@
     {
       "type": "streamable-http",
       "url": "https://fathom-mcp-server.com/mcp"
+    },
+    {
+      "type": "sse",
+      "url": "https://fathom-mcp-server.com/sse"
     }
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import {
   healthRouter,
   mcpRouter,
   oauthRouter,
+  sseConnectionRouter,
+  sseMessageRouter,
   wellKnownRouter,
 } from "./routes";
 import { config } from "./shared/config";
@@ -45,6 +47,8 @@ app.use("/health", healthRouter);
 app.use("/.well-known", wellKnownRouter);
 app.use("/oauth", oauthRouter);
 app.use("/mcp", bearerAuthMiddleware, userRateLimiter, mcpRouter);
+app.use("/sse", bearerAuthMiddleware, userRateLimiter, sseConnectionRouter);
+app.use("/messages", bearerAuthMiddleware, userRateLimiter, sseMessageRouter);
 
 // Block common attack vectors and malicious bots (Express 5 syntax)
 app.use(
@@ -81,6 +85,8 @@ app.get("/api", (_req, res) => {
       wellKnown: "/.well-known/oauth-protected-resource",
       oauth: "/oauth/authorize",
       mcp: "/mcp",
+      sse: "/sse",
+      sseMessages: "/messages",
     },
   });
 });

--- a/src/modules/sessions/manager.ts
+++ b/src/modules/sessions/manager.ts
@@ -1,6 +1,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { randomUUID } from "crypto";
+import type { Request, Response } from "express";
 import { logger } from "../../middleware/logger";
 import {
   IDLE_TRANSPORT_REAP_INTERVAL_MS,
@@ -25,13 +27,22 @@ interface ActiveTransport {
   lastAccessedAt: Date;
 }
 
+interface ActiveSseTransport {
+  transport: SSEServerTransport;
+  server: McpServer;
+  userId: string;
+  lastAccessedAt: Date;
+}
+
 export class SessionManager {
   private activeTransports: Map<string, ActiveTransport>;
+  private activeSseTransports: Map<string, ActiveSseTransport>;
   private cleanupIntervalId: NodeJS.Timeout | null = null;
   private reapIntervalId: NodeJS.Timeout | null = null;
 
   constructor() {
     this.activeTransports = new Map();
+    this.activeSseTransports = new Map();
   }
 
   async createSession(userId: string): Promise<StreamableHTTPServerTransport> {
@@ -73,6 +84,79 @@ export class SessionManager {
     await server.connect(transport);
 
     return transport;
+  }
+
+  async createSseSession(userId: string, res: Response): Promise<void> {
+    const transport = new SSEServerTransport("/messages", res);
+    const sessionId = transport.sessionId;
+
+    transport.onclose = async () => {
+      await this.handleTransportClosed(sessionId);
+    };
+
+    const server = createToolServer((id) => this.getActiveTransport(id));
+
+    try {
+      await insertSession(sessionId, userId);
+    } catch (error) {
+      logger.error(
+        { sessionId, userId, error },
+        "SSE session initialization failed",
+      );
+      throw error;
+    }
+
+    this.cacheSseTransport(sessionId, userId, transport, server);
+    await server.connect(transport);
+  }
+
+  async handleSseMessage(
+    sessionId: string,
+    req: Request,
+    res: Response,
+  ): Promise<void> {
+    const cached = this.activeSseTransports.get(sessionId);
+
+    if (!cached) {
+      throw AppError.notFound("Session");
+    }
+
+    cached.lastAccessedAt = new Date();
+    await cached.transport.handlePostMessage(req, res);
+  }
+
+  private cacheSseTransport(
+    sessionId: string,
+    userId: string,
+    transport: SSEServerTransport,
+    server: McpServer,
+  ): void {
+    this.activeSseTransports.set(sessionId, {
+      transport,
+      server,
+      userId,
+      lastAccessedAt: new Date(),
+    });
+
+    const activeCount =
+      this.activeTransports.size + this.activeSseTransports.size;
+
+    if (activeCount > MAX_ACTIVE_TRANSPORTS_WARN) {
+      logger.warn(
+        {
+          sessionId,
+          userId,
+          activeCount,
+          threshold: MAX_ACTIVE_TRANSPORTS_WARN,
+        },
+        "Active transport count exceeds warning threshold",
+      );
+    }
+
+    logger.info(
+      { sessionId, userId, activeCount },
+      "SSE transport stored in memory",
+    );
   }
 
   private cacheTransport(
@@ -121,10 +205,13 @@ export class SessionManager {
 
   async terminateSession(sessionId: string): Promise<void> {
     const cachedTransport = this.activeTransports.get(sessionId);
+    const cachedSseTransport = this.activeSseTransports.get(sessionId);
 
-    if (cachedTransport) {
+    const entry = cachedTransport ?? cachedSseTransport;
+
+    if (entry) {
       try {
-        await cachedTransport.server.close();
+        await entry.server.close();
       } catch (error) {
         logger.error({ sessionId, error }, "Error closing server");
       }
@@ -132,6 +219,7 @@ export class SessionManager {
 
     await this.persistTermination(sessionId);
     this.activeTransports.delete(sessionId);
+    this.activeSseTransports.delete(sessionId);
 
     logger.info({ sessionId }, "Session terminated");
   }
@@ -153,6 +241,7 @@ export class SessionManager {
       // Error already thrown as AppError.server, can't propagate from SDK callback
     }
     this.activeTransports.delete(sessionId);
+    this.activeSseTransports.delete(sessionId);
   }
 
   async reapIdleTransports(): Promise<void> {
@@ -166,10 +255,19 @@ export class SessionManager {
       }
     }
 
+    for (const [sessionId, entry] of this.activeSseTransports) {
+      const idleMs = now - entry.lastAccessedAt.getTime();
+      if (idleMs > IDLE_TRANSPORT_TTL_MS) {
+        idleSessions.push(sessionId);
+      }
+    }
+
     if (idleSessions.length === 0) return;
 
     const closePromises = idleSessions.map(async (sessionId) => {
-      const entry = this.activeTransports.get(sessionId);
+      const entry =
+        this.activeTransports.get(sessionId) ??
+        this.activeSseTransports.get(sessionId);
       if (entry) {
         try {
           await entry.server.close();
@@ -177,6 +275,7 @@ export class SessionManager {
           logger.error({ sessionId, error }, "Error closing idle server");
         }
         this.activeTransports.delete(sessionId);
+        this.activeSseTransports.delete(sessionId);
       }
       try {
         await markSessionTerminated(sessionId);
@@ -188,7 +287,10 @@ export class SessionManager {
     await Promise.all(closePromises);
 
     logger.info(
-      { reaped: idleSessions.length, remaining: this.activeTransports.size },
+      {
+        reaped: idleSessions.length,
+        remaining: this.activeTransports.size + this.activeSseTransports.size,
+      },
       "Reaped idle transports",
     );
   }
@@ -199,7 +301,9 @@ export class SessionManager {
 
       if (expiredSessionIds.length > 0) {
         const closePromises = expiredSessionIds.map(async (sessionId) => {
-          const cachedTransport = this.activeTransports.get(sessionId);
+          const cachedTransport =
+            this.activeTransports.get(sessionId) ??
+            this.activeSseTransports.get(sessionId);
           if (cachedTransport) {
             try {
               await cachedTransport.server.close();
@@ -210,6 +314,7 @@ export class SessionManager {
               );
             }
             this.activeTransports.delete(sessionId);
+            this.activeSseTransports.delete(sessionId);
           }
         });
 
@@ -279,22 +384,26 @@ export class SessionManager {
 
     this.stopCleanupScheduler();
 
-    const closePromises = Array.from(this.activeTransports.entries()).map(
-      async ([sessionId, { server }]) => {
-        try {
-          await server.close();
-          await this.persistTermination(sessionId);
-        } catch (error) {
-          logger.error(
-            { sessionId, error },
-            "Error closing server during shutdown",
-          );
-        }
-      },
-    );
+    const allEntries = [
+      ...Array.from(this.activeTransports.entries()),
+      ...Array.from(this.activeSseTransports.entries()),
+    ];
+
+    const closePromises = allEntries.map(async ([sessionId, { server }]) => {
+      try {
+        await server.close();
+        await this.persistTermination(sessionId);
+      } catch (error) {
+        logger.error(
+          { sessionId, error },
+          "Error closing server during shutdown",
+        );
+      }
+    });
 
     await Promise.all(closePromises);
     this.activeTransports.clear();
+    this.activeSseTransports.clear();
 
     logger.info("Session manager shutdown complete");
   }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,4 +2,5 @@ export { default as docsRouter } from "./docs";
 export { default as healthRouter } from "./health";
 export { default as mcpRouter } from "./mcp";
 export { default as oauthRouter } from "./oauth";
+export { sseConnectionRouter, sseMessageRouter } from "./sse";
 export { default as wellKnownRouter } from "./well-known";

--- a/src/routes/sse.ts
+++ b/src/routes/sse.ts
@@ -1,0 +1,30 @@
+import type { Request } from "express";
+import { Router } from "express";
+import type { SessionManager } from "../modules/sessions/manager";
+
+function getSessionManager(req: Request): SessionManager {
+  return req.app.locals.sessionManager;
+}
+
+export const sseConnectionRouter = Router();
+export const sseMessageRouter = Router();
+
+sseConnectionRouter.get("/", (req, res, next) => {
+  const sessionManager = getSessionManager(req);
+  sessionManager.createSseSession(req.userId!, res).catch(next);
+});
+
+sseMessageRouter.post("/", (req, res, next) => {
+  const sessionManager = getSessionManager(req);
+  const sessionId = req.query["sessionId"] as string | undefined;
+
+  if (!sessionId) {
+    res.status(400).json({
+      error: "bad_request",
+      error_description: "Missing sessionId query parameter",
+    });
+    return;
+  }
+
+  sessionManager.handleSseMessage(sessionId, req, res).catch(next);
+});

--- a/src/test/modules/sessions/manager.test.ts
+++ b/src/test/modules/sessions/manager.test.ts
@@ -40,6 +40,16 @@ vi.mock("@modelcontextprotocol/sdk/server/streamableHttp.js", () => ({
   },
 }));
 
+vi.mock("@modelcontextprotocol/sdk/server/sse.js", () => ({
+  SSEServerTransport: class MockSseTransport {
+    sessionId = "mock-sse-session-id";
+    handlePostMessage = vi.fn();
+    onclose: (() => void) | null = null;
+
+    constructor(_endpoint: string, _res: unknown) {}
+  },
+}));
+
 import { cleanupExpiredMcpServerOAuthData } from "../../../modules/oauth/service";
 import { SessionManager } from "../../../modules/sessions/manager";
 import {
@@ -262,6 +272,59 @@ describe("SessionManager", () => {
       await sessionManager.shutdown();
 
       expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+
+  describe("createSseSession", () => {
+    it("creates an SSE session and caches it", async () => {
+      vi.mocked(insertSession).mockResolvedValue(undefined);
+      const mockRes = {} as unknown;
+
+      await sessionManager.createSseSession("user-123", mockRes as never);
+
+      expect(insertSession).toHaveBeenCalledWith(
+        "mock-sse-session-id",
+        "user-123",
+      );
+      expect(mockServerConnect).toHaveBeenCalled();
+    });
+
+    it("throws and does not cache when insertSession fails", async () => {
+      vi.mocked(insertSession).mockRejectedValue(new Error("DB error"));
+      const mockRes = {} as unknown;
+
+      await expect(
+        sessionManager.createSseSession("user-123", mockRes as never),
+      ).rejects.toThrow("DB error");
+    });
+  });
+
+  describe("handleSseMessage", () => {
+    it("throws when SSE session not found", async () => {
+      const mockReq = {} as never;
+      const mockRes = {} as never;
+
+      await expect(
+        sessionManager.handleSseMessage("nonexistent", mockReq, mockRes),
+      ).rejects.toThrow();
+    });
+
+    it("delegates to handlePostMessage on the SSE transport", async () => {
+      vi.mocked(insertSession).mockResolvedValue(undefined);
+      const mockRes = {} as unknown;
+
+      await sessionManager.createSseSession("user-123", mockRes as never);
+
+      const mockReq = {} as never;
+      const mockReqRes = {} as never;
+
+      await sessionManager.handleSseMessage(
+        "mock-sse-session-id",
+        mockReq,
+        mockReqRes,
+      );
+
+      expect(mockServerConnect).toHaveBeenCalled();
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
         "src/routes/docs.ts",
         "src/routes/mcp.ts",
         "src/routes/oauth.ts",
+        "src/routes/sse.ts",
         "src/routes/well-known.ts",
         "src/middleware/logger.ts",
         "src/middleware/rateLimit.ts",


### PR DESCRIPTION
## Summary

Adds a legacy SSE transport endpoint (`/sse`) alongside the existing Streamable HTTP endpoint (`/mcp`), enabling compatibility with MCP clients that have not yet adopted the newer transport including Perplexity Desktop for Mac. The existing `/mcp` endpoint and all Streamable HTTP behavior are unchanged.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Other (describe below)

## Related Issues

Feature for #20

---

**Changes in this PR:**
- `src/modules/sessions/manager.ts` — Added a separate `ActiveSseTransport` interface and `activeSseTransports` map; added `createSseSession` and `handleSseMessage` methods; all existing Streamable HTTP session logic is untouched
- `src/routes/sse.ts` — New router exposing `GET /sse` (SSE connection) and `POST /messages` (client-to-server messages)
- `src/index.ts` — Mounted `/sse` and `/messages` behind the same `bearerAuthMiddleware` and `userRateLimiter` as `/mcp`
- `server.json` — Added `sse` remote entry pointing to `/sse`
- `src/test/modules/sessions/manager.test.ts` — Added `SSEServerTransport` mock and tests for `createSseSession` and `handleSseMessage`
- `vitest.config.ts` — Excluded `sse.ts` from coverage, consistent with other thin routing files

## Testing
This branch needs to be merged to staging and testing needs to be done through there before it can move to production.