### PR TITLE
Add prompt registration for latest meeting summary

### DIFF
--- a/src/test/tools/server.test.ts
+++ b/src/test/tools/server.test.ts
@@ -4,12 +4,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../db", () => ({ db: {} }));
 
 const mockRegisterTool = vi.fn();
+const mockRegisterPrompt = vi.fn();
 const mockConnect = vi.fn();
 const mockClose = vi.fn();
 
 vi.mock("@modelcontextprotocol/sdk/server/mcp.js", () => ({
   McpServer: class MockMcpServer {
     registerTool = mockRegisterTool;
+    registerPrompt = mockRegisterPrompt;
     connect = mockConnect;
     close = mockClose;
   },
@@ -44,6 +46,7 @@ describe("createToolServer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRegisterTool.mockClear();
+    mockRegisterPrompt.mockClear();
     mockConnect.mockClear();
     mockClose.mockClear();
     getActiveTransportFn = vi.fn<GetActiveTransportFn>();
@@ -129,6 +132,21 @@ describe("createToolServer", () => {
         expect(config.description).toBeDefined();
         expect(config.inputSchema).toBeDefined();
       }
+    });
+
+    it("registers latest_meeting_summary prompt", () => {
+      createToolServer(getActiveTransportFn);
+
+      const registeredPrompts = mockRegisterPrompt.mock.calls;
+      const promptNames = registeredPrompts.map(([name]) => name);
+
+      expect(promptNames).toContain("latest_meeting_short_summary");
+
+      const [, config] = registeredPrompts.find(
+        ([name]) => name === "latest_meeting_short_summary",
+      )!;
+      expect(config.title).toBeDefined();
+      expect(config.description).toBeDefined();
     });
   });
 

--- a/src/tools/server.ts
+++ b/src/tools/server.ts
@@ -52,7 +52,13 @@ export function createToolServer(
 ): McpServer {
   const server = new McpServer(
     { name: "fathom-mcp", version: config.version },
-    { capabilities: { logging: {}, tools: { listChanged: false } } },
+    {
+      capabilities: {
+        logging: {},
+        tools: { listChanged: false },
+        prompts: { listChanged: false },
+      },
+    },
   );
 
   server.registerTool(
@@ -150,6 +156,36 @@ export function createToolServer(
       const userId = getUserId(getActiveTransportFn, extra);
       return listTeamMembers(userId, args);
     },
+  );
+
+  server.registerPrompt(
+    "latest_meeting_short_summary",
+    {
+      title: "Summarize Latest Meeting",
+      description:
+        "Get a short summary of the transcript from your most recent Fathom meeting",
+    },
+    async () => ({
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `Call list_meetings with limit 1 to get my most recent meeting.
+
+                  Then call get_transcript using the recording_id from that result.
+
+                  Present your response in this format:
+
+                  **[meeting title] — [date]**
+                  Attendees: [names]
+
+                  **Short Summary**
+                  ...`,
+          },
+        },
+      ],
+    }),
   );
 
   return server;


### PR DESCRIPTION
## Summary

- Enhanced the createToolServer function to include a new prompt, "latest_meeting_short_summary", with a title and description.
- Updated the server capabilities to include prompts.
- Added a test case to verify the registration of the new prompt and its configuration in server.test.ts.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Other (describe below)