### PR TITLE
Add refresh token functionality to OAuth system

### DIFF
--- a/drizzle/migrations/0001_pink_marauders.sql
+++ b/drizzle/migrations/0001_pink_marauders.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "mcp_server_refresh_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"token" text NOT NULL,
+	"user_id" text NOT NULL,
+	"scope" text DEFAULT 'fathom:read' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"revoked_at" timestamp,
+	CONSTRAINT "mcp_server_refresh_tokens_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE INDEX "mcp_server_refresh_tokens_expires_at_idx" ON "mcp_server_refresh_tokens" USING btree ("expires_at");

--- a/drizzle/migrations/meta/0001_snapshot.json
+++ b/drizzle/migrations/meta/0001_snapshot.json
@@ -1,0 +1,592 @@
+{
+  "id": "efff21c4-b680-49b0-984e-19dfb56c23cd",
+  "prevId": "338e35bf-d42f-4f6a-a134-8fa01a94b09c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.fathom_oauth_tokens": {
+      "name": "fathom_oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fathom_oauth_tokens_expires_at_idx": {
+          "name": "fathom_oauth_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "fathom_oauth_tokens_user_id_unique": {
+          "name": "fathom_oauth_tokens_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server_access_tokens": {
+      "name": "mcp_server_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fathom:read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_server_access_tokens_expires_at_idx": {
+          "name": "mcp_server_access_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_server_access_tokens_token_unique": {
+          "name": "mcp_server_access_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server_authorization_codes": {
+      "name": "mcp_server_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_redirect_uri": {
+          "name": "client_redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_code_challenge": {
+          "name": "client_code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_code_challenge_method": {
+          "name": "client_code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fathom:read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_server_authorization_codes_expires_at_idx": {
+          "name": "mcp_server_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_server_authorization_codes_code_unique": {
+          "name": "mcp_server_authorization_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server_oauth_clients": {
+      "name": "mcp_server_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_server_oauth_clients_client_id_unique": {
+          "name": "mcp_server_oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server_oauth_states": {
+      "name": "mcp_server_oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_redirect_uri": {
+          "name": "client_redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_state": {
+          "name": "client_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_code_challenge": {
+          "name": "client_code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_code_challenge_method": {
+          "name": "client_code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mcp_server_oauth_states_expires_at_idx": {
+          "name": "mcp_server_oauth_states_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_server_oauth_states_state_unique": {
+          "name": "mcp_server_oauth_states_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_server_refresh_tokens": {
+      "name": "mcp_server_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fathom:read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_server_refresh_tokens_expires_at_idx": {
+          "name": "mcp_server_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_server_refresh_tokens_token_unique": {
+          "name": "mcp_server_refresh_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_sessions": {
+      "name": "mcp_sessions",
+      "schema": "",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "terminated_at": {
+          "name": "terminated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_sessions_expires_at_idx": {
+          "name": "mcp_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_sessions_terminated_at_idx": {
+          "name": "mcp_sessions_terminated_at_idx",
+          "columns": [
+            {
+              "expression": "terminated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1770005854841,
       "tag": "0000_overjoyed_kulan_gath",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1775002788067,
+      "tag": "0001_pink_marauders",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -84,6 +84,22 @@ export const mcpServerOAuthClients = pgTable("mcp_server_oauth_clients", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
+export const mcpServerRefreshTokens = pgTable(
+  "mcp_server_refresh_tokens",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    token: text("token").notNull().unique(),
+    userId: text("user_id").notNull(),
+    scope: text("scope").notNull().default("fathom:read"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    revokedAt: timestamp("revoked_at"),
+  },
+  (table) => [
+    index("mcp_server_refresh_tokens_expires_at_idx").on(table.expiresAt),
+  ],
+);
+
 export const mcpSessions = pgTable(
   "mcp_sessions",
   {
@@ -109,5 +125,8 @@ export type McpServerAuthorizationCode = InferSelectModel<
 >;
 export type McpServerOAuthClient = InferSelectModel<
   typeof mcpServerOAuthClients
+>;
+export type McpServerRefreshToken = InferSelectModel<
+  typeof mcpServerRefreshTokens
 >;
 export type McpSession = InferSelectModel<typeof mcpSessions>;

--- a/src/modules/oauth/controller.ts
+++ b/src/modules/oauth/controller.ts
@@ -3,6 +3,7 @@ import type { Request, Response } from "express";
 import { config } from "../../shared/config";
 import {
   FATHOM_API_SCOPE,
+  MCP_SERVER_ACCESS_TOKEN_TTL_MS,
   OAUTH_GRANT_TYPE_AUTH_CODE,
   OAUTH_GRANT_TYPE_REFRESH,
   OAUTH_RESPONSE_TYPE_CODE,
@@ -19,9 +20,11 @@ import {
 } from "./schema";
 import {
   consumeMcpServerAuthorizationCode,
+  consumeMcpServerRefreshToken,
   createMcpServerAccessToken,
   createMcpServerAuthorizationCode,
   createMcpServerOAuthState,
+  createMcpServerRefreshToken,
   deleteMcpServerOAuthState,
   findMcpServerOAuthClient,
   getFathomOAuthToken,
@@ -141,10 +144,20 @@ export async function exchangeCodeForMcpAccessToken(
   req: Request,
   res: Response,
 ) {
-  const { code, code_verifier } = exchangeCodeForMcpAccessTokenReqSchema.parse(
-    req.body,
-  );
+  const parsed = exchangeCodeForMcpAccessTokenReqSchema.parse(req.body);
 
+  if (parsed.grant_type === "refresh_token") {
+    return handleRefreshTokenGrant(parsed.refresh_token, res);
+  }
+
+  return handleAuthorizationCodeGrant(parsed.code, parsed.code_verifier, res);
+}
+
+async function handleAuthorizationCodeGrant(
+  code: string,
+  codeVerifier: string | undefined,
+  res: Response,
+) {
   const authorizationCodeRecord = await consumeMcpServerAuthorizationCode(code);
   if (!authorizationCodeRecord) {
     throw AppError.oauth(
@@ -156,12 +169,12 @@ export async function exchangeCodeForMcpAccessToken(
     authorizationCodeRecord;
 
   if (clientCodeChallenge && clientCodeChallengeMethod) {
-    if (!code_verifier) {
+    if (!codeVerifier) {
       throw AppError.validation("Missing code_verifier for MCP Server PKCE");
     }
 
     const isValid = verifyMcpServerPKCE(
-      code_verifier,
+      codeVerifier,
       clientCodeChallenge,
       clientCodeChallengeMethod,
     );
@@ -174,11 +187,31 @@ export async function exchangeCodeForMcpAccessToken(
     }
   }
 
-  const mcpServerAccessToken = await createMcpServerAccessToken(userId, scope);
+  await issueTokenPair(userId, scope, res);
+}
+
+async function handleRefreshTokenGrant(refreshToken: string, res: Response) {
+  const record = await consumeMcpServerRefreshToken(refreshToken);
+  if (!record) {
+    throw AppError.oauth(
+      "invalid_grant",
+      "Invalid, expired, or revoked refresh token",
+    );
+  }
+
+  await issueTokenPair(record.userId, record.scope, res);
+}
+
+async function issueTokenPair(userId: string, scope: string, res: Response) {
+  const accessToken = await createMcpServerAccessToken(userId, scope);
+  const refreshToken = await createMcpServerRefreshToken(userId, scope);
+  const expiresInSeconds = Math.floor(MCP_SERVER_ACCESS_TOKEN_TTL_MS / 1000);
 
   res.json({
-    access_token: mcpServerAccessToken,
+    access_token: accessToken,
     token_type: "Bearer",
+    expires_in: expiresInSeconds,
+    refresh_token: refreshToken,
     scope,
   });
 }

--- a/src/modules/oauth/schema.ts
+++ b/src/modules/oauth/schema.ts
@@ -30,10 +30,20 @@ export const completeFathomAuthAndRedirectClientReqSchema = z.object({
   state: z.string(),
 });
 
-export const exchangeCodeForMcpAccessTokenReqSchema = z.object({
-  grant_type: z.literal("authorization_code"),
-  code: z.string(),
-  client_id: z.string().optional(),
-  redirect_uri: z.string().optional(),
-  code_verifier: z.string().optional(),
-});
+export const exchangeCodeForMcpAccessTokenReqSchema = z.discriminatedUnion(
+  "grant_type",
+  [
+    z.object({
+      grant_type: z.literal("authorization_code"),
+      code: z.string(),
+      client_id: z.string().optional(),
+      redirect_uri: z.string().optional(),
+      code_verifier: z.string().optional(),
+    }),
+    z.object({
+      grant_type: z.literal("refresh_token"),
+      refresh_token: z.string(),
+      client_id: z.string().optional(),
+    }),
+  ],
+);

--- a/src/modules/oauth/service.ts
+++ b/src/modules/oauth/service.ts
@@ -7,17 +7,20 @@ import {
   mcpServerAuthorizationCodes,
   mcpServerOAuthClients,
   mcpServerOAuthStates,
+  mcpServerRefreshTokens,
   type FathomOAuthToken,
   type McpServerAccessToken,
   type McpServerAuthorizationCode,
   type McpServerOAuthClient,
   type McpServerOAuthState,
+  type McpServerRefreshToken,
 } from "../../db";
 import {
   MCP_SERVER_ACCESS_TOKEN_TTL_MS,
   MCP_SERVER_AUTH_CODE_TTL_MS,
   MCP_SERVER_DEFAULT_SCOPE,
   MCP_SERVER_OAUTH_STATE_TTL_MS,
+  MCP_SERVER_REFRESH_TOKEN_TTL_MS,
   STALE_SESSION_CUTOFF_MS,
 } from "../../shared/constants";
 import { encrypt } from "../../utils/crypto";
@@ -181,6 +184,51 @@ export async function getMcpServerAccessToken(
   return accessTokenRecords[0] ?? null;
 }
 
+export async function createMcpServerRefreshToken(
+  userId: string,
+  scope: string,
+): Promise<string> {
+  const token = randomUUID();
+  const expiresAt = new Date(Date.now() + MCP_SERVER_REFRESH_TOKEN_TTL_MS);
+
+  await db.insert(mcpServerRefreshTokens).values({
+    token,
+    userId,
+    scope,
+    expiresAt,
+  });
+
+  return token;
+}
+
+export async function consumeMcpServerRefreshToken(
+  token: string,
+): Promise<McpServerRefreshToken | null> {
+  return await db.transaction(async (tx) => {
+    const records = await tx
+      .select()
+      .from(mcpServerRefreshTokens)
+      .where(
+        and(
+          eq(mcpServerRefreshTokens.token, token),
+          gt(mcpServerRefreshTokens.expiresAt, new Date()),
+          isNull(mcpServerRefreshTokens.revokedAt),
+        ),
+      )
+      .limit(1);
+
+    const record = records[0];
+    if (!record) return null;
+
+    await tx
+      .update(mcpServerRefreshTokens)
+      .set({ revokedAt: new Date() })
+      .where(eq(mcpServerRefreshTokens.token, token));
+
+    return record;
+  });
+}
+
 export async function insertFathomToken(
   userId: string,
   token: FathomTokenResType,
@@ -238,37 +286,49 @@ export async function cleanupExpiredMcpServerOAuthData(): Promise<{
   oauthStates: number;
   authorizationCodes: number;
   accessTokens: number;
+  refreshTokens: number;
 }> {
   const now = new Date();
   const staleUsedCodesCutoff = new Date(
     now.getTime() - STALE_SESSION_CUTOFF_MS,
   );
 
-  const [statesResult, codesResult, tokensResult] = await Promise.all([
-    db
-      .delete(mcpServerOAuthStates)
-      .where(lt(mcpServerOAuthStates.expiresAt, now)),
+  const [statesResult, codesResult, tokensResult, refreshResult] =
+    await Promise.all([
+      db
+        .delete(mcpServerOAuthStates)
+        .where(lt(mcpServerOAuthStates.expiresAt, now)),
 
-    db
-      .delete(mcpServerAuthorizationCodes)
-      .where(
-        or(
-          lt(mcpServerAuthorizationCodes.expiresAt, now),
-          and(
-            isNotNull(mcpServerAuthorizationCodes.used),
-            lt(mcpServerAuthorizationCodes.used, staleUsedCodesCutoff),
+      db
+        .delete(mcpServerAuthorizationCodes)
+        .where(
+          or(
+            lt(mcpServerAuthorizationCodes.expiresAt, now),
+            and(
+              isNotNull(mcpServerAuthorizationCodes.used),
+              lt(mcpServerAuthorizationCodes.used, staleUsedCodesCutoff),
+            ),
           ),
         ),
-      ),
 
-    db
-      .delete(mcpServerAccessTokens)
-      .where(lt(mcpServerAccessTokens.expiresAt, now)),
-  ]);
+      db
+        .delete(mcpServerAccessTokens)
+        .where(lt(mcpServerAccessTokens.expiresAt, now)),
+
+      db
+        .delete(mcpServerRefreshTokens)
+        .where(
+          or(
+            lt(mcpServerRefreshTokens.expiresAt, now),
+            isNotNull(mcpServerRefreshTokens.revokedAt),
+          ),
+        ),
+    ]);
 
   return {
     oauthStates: statesResult.rowCount ?? 0,
     authorizationCodes: codesResult.rowCount ?? 0,
     accessTokens: tokensResult.rowCount ?? 0,
+    refreshTokens: refreshResult.rowCount ?? 0,
   };
 }

--- a/src/modules/sessions/controller.ts
+++ b/src/modules/sessions/controller.ts
@@ -15,30 +15,16 @@ export async function routeToSessionOrInitialize(req: Request, res: Response) {
     userId: req.userId,
   });
 
-  if (sessionId) {
-    const session = await sessionManager.retrieveSession(sessionId);
-
-    if (!session && isInitializeRequest(req.body)) {
-      const transport = await sessionManager.createSession(userId!);
-      await transport.handleRequest(req, res, req.body);
-      return;
-    }
-
-    if (!session) {
-      throw AppError.notFound("Session");
-    }
-
-    if (session.userId !== userId) {
-      throw AppError.forbidden("Session does not belong to this user");
-    }
-
-    await session.transport.handleRequest(req, res, req.body);
-    return;
-  }
-
   if (isInitializeRequest(req.body)) {
     if (!userId) {
       throw AppError.auth("unauthorized", "Unauthorized");
+    }
+
+    if (sessionId) {
+      const existingSession = await sessionManager.retrieveSession(sessionId);
+      if (existingSession) {
+        await sessionManager.terminateSession(sessionId);
+      }
     }
 
     const transport = await sessionManager.createSession(userId);
@@ -46,10 +32,23 @@ export async function routeToSessionOrInitialize(req: Request, res: Response) {
     return;
   }
 
-  throw AppError.session(
-    "bad_request",
-    "Missing session ID for non-initialize request",
-  );
+  if (!sessionId) {
+    throw AppError.session(
+      "bad_request",
+      "Missing session ID for non-initialize request",
+    );
+  }
+
+  const session = await sessionManager.retrieveSession(sessionId);
+  if (!session) {
+    throw AppError.notFound("Session");
+  }
+
+  if (session.userId !== userId) {
+    throw AppError.forbidden("Session does not belong to this user");
+  }
+
+  await session.transport.handleRequest(req, res, req.body);
 }
 
 export async function retrieveAuthenticatedSession(

--- a/src/modules/sessions/manager.ts
+++ b/src/modules/sessions/manager.ts
@@ -336,7 +336,8 @@ export class SessionManager {
       const totalOAuthCleaned =
         oauthCleanupResult.oauthStates +
         oauthCleanupResult.authorizationCodes +
-        oauthCleanupResult.accessTokens;
+        oauthCleanupResult.accessTokens +
+        oauthCleanupResult.refreshTokens;
 
       if (totalOAuthCleaned > 0) {
         logger.info(oauthCleanupResult, "Cleaned up expired OAuth data");

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,5 +1,6 @@
 // MCP Server OAuth (we are the provider)
 export const MCP_SERVER_ACCESS_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+export const MCP_SERVER_REFRESH_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
 export const MCP_SERVER_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
 export const MCP_SERVER_AUTH_CODE_TTL_MS = 5 * 60 * 1000;
 export const MCP_SERVER_DEFAULT_SCOPE = "fathom:read";

--- a/src/test/modules/oauth/controller.test.ts
+++ b/src/test/modules/oauth/controller.test.ts
@@ -29,9 +29,11 @@ import {
 } from "../../../modules/oauth/controller";
 import {
   consumeMcpServerAuthorizationCode,
+  consumeMcpServerRefreshToken,
   createMcpServerAccessToken,
   createMcpServerAuthorizationCode,
   createMcpServerOAuthState,
+  createMcpServerRefreshToken,
   deleteMcpServerOAuthState,
   findMcpServerOAuthClient,
   getFathomOAuthToken,
@@ -303,11 +305,12 @@ describe("oauth/controller", () => {
   });
 
   describe("exchangeCodeForMcpAccessToken", () => {
-    it("exchanges code for access token", async () => {
+    it("exchanges code for access token with refresh token", async () => {
       vi.mocked(consumeMcpServerAuthorizationCode).mockResolvedValue(
         createMockAuthorizationCode(),
       );
       vi.mocked(createMcpServerAccessToken).mockResolvedValue("access-token");
+      vi.mocked(createMcpServerRefreshToken).mockResolvedValue("refresh-token");
 
       const req = createMockRequest({
         body: {
@@ -322,6 +325,8 @@ describe("oauth/controller", () => {
       expect(res.json).toHaveBeenCalledWith({
         access_token: "access-token",
         token_type: "Bearer",
+        expires_in: expect.any(Number),
+        refresh_token: "refresh-token",
         scope: "fathom:read",
       });
     });
@@ -349,6 +354,7 @@ describe("oauth/controller", () => {
       );
       vi.mocked(verifyMcpServerPKCE).mockReturnValue(true);
       vi.mocked(createMcpServerAccessToken).mockResolvedValue("access-token");
+      vi.mocked(createMcpServerRefreshToken).mockResolvedValue("refresh-token");
 
       const req = createMockRequest({
         body: {
@@ -402,6 +408,59 @@ describe("oauth/controller", () => {
         body: {
           grant_type: "authorization_code",
           code: "auth-code",
+        },
+      });
+      const res = createMockResponse();
+
+      await expect(exchangeCodeForMcpAccessToken(req, res)).rejects.toThrow();
+    });
+
+    it("issues new token pair via refresh_token grant", async () => {
+      vi.mocked(consumeMcpServerRefreshToken).mockResolvedValue({
+        id: "mock-id",
+        token: "old-refresh-token",
+        userId: "user-id",
+        scope: "fathom:read",
+        createdAt: new Date(),
+        expiresAt: new Date(Date.now() + 86400000),
+        revokedAt: null,
+      });
+      vi.mocked(createMcpServerAccessToken).mockResolvedValue(
+        "new-access-token",
+      );
+      vi.mocked(createMcpServerRefreshToken).mockResolvedValue(
+        "new-refresh-token",
+      );
+
+      const req = createMockRequest({
+        body: {
+          grant_type: "refresh_token",
+          refresh_token: "old-refresh-token",
+        },
+      });
+      const res = createMockResponse();
+
+      await exchangeCodeForMcpAccessToken(req, res);
+
+      expect(consumeMcpServerRefreshToken).toHaveBeenCalledWith(
+        "old-refresh-token",
+      );
+      expect(res.json).toHaveBeenCalledWith({
+        access_token: "new-access-token",
+        token_type: "Bearer",
+        expires_in: expect.any(Number),
+        refresh_token: "new-refresh-token",
+        scope: "fathom:read",
+      });
+    });
+
+    it("throws on invalid refresh token", async () => {
+      vi.mocked(consumeMcpServerRefreshToken).mockResolvedValue(null);
+
+      const req = createMockRequest({
+        body: {
+          grant_type: "refresh_token",
+          refresh_token: "invalid-token",
         },
       });
       const res = createMockResponse();

--- a/src/test/modules/oauth/service.test.ts
+++ b/src/test/modules/oauth/service.test.ts
@@ -14,15 +14,18 @@ vi.mock("../../../db", () => ({
   mcpServerAuthorizationCodes: {},
   mcpServerOAuthClients: {},
   mcpServerOAuthStates: {},
+  mcpServerRefreshTokens: {},
 }));
 
 import { db } from "../../../db";
 import {
   cleanupExpiredMcpServerOAuthData,
   consumeMcpServerAuthorizationCode,
+  consumeMcpServerRefreshToken,
   createMcpServerAccessToken,
   createMcpServerAuthorizationCode,
   createMcpServerOAuthState,
+  createMcpServerRefreshToken,
   deleteMcpServerOAuthState,
   findMcpServerOAuthClient,
   getFathomOAuthToken,
@@ -364,6 +367,76 @@ describe("oauth/service", () => {
     });
   });
 
+  describe("createMcpServerRefreshToken", () => {
+    it("creates refresh token and returns token string", async () => {
+      vi.mocked(db.insert).mockReturnValue({
+        values: vi.fn().mockResolvedValue(undefined),
+      } as never);
+
+      const result = await createMcpServerRefreshToken(
+        "user-id",
+        "fathom:read",
+      );
+
+      expect(typeof result).toBe("string");
+      expect(result.length).toBeGreaterThan(0);
+      expect(db.insert).toHaveBeenCalled();
+    });
+  });
+
+  describe("consumeMcpServerRefreshToken", () => {
+    it("returns and revokes token when valid", async () => {
+      const mockToken = {
+        token: "refresh-token",
+        userId: "user-id",
+        scope: "fathom:read",
+        revokedAt: null,
+      };
+      vi.mocked(db.transaction).mockImplementation(async (callback) => {
+        const tx = {
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([mockToken]),
+              }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({
+            set: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue(undefined),
+            }),
+          }),
+        };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return callback(tx as any);
+      });
+
+      const result = await consumeMcpServerRefreshToken("refresh-token");
+
+      expect(result).toEqual(mockToken);
+    });
+
+    it("returns null when token not found, expired, or revoked", async () => {
+      vi.mocked(db.transaction).mockImplementation(async (callback) => {
+        const tx = {
+          select: vi.fn().mockReturnValue({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue([]),
+              }),
+            }),
+          }),
+        };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return callback(tx as any);
+      });
+
+      const result = await consumeMcpServerRefreshToken("invalid-token");
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe("cleanupExpiredMcpServerOAuthData", () => {
     it("deletes expired data and returns counts", async () => {
       vi.mocked(db.delete).mockReturnValue({
@@ -375,6 +448,7 @@ describe("oauth/service", () => {
       expect(result.oauthStates).toBe(5);
       expect(result.authorizationCodes).toBe(5);
       expect(result.accessTokens).toBe(5);
+      expect(result.refreshTokens).toBe(5);
     });
 
     it("handles null rowCount", async () => {
@@ -387,6 +461,7 @@ describe("oauth/service", () => {
       expect(result.oauthStates).toBe(0);
       expect(result.authorizationCodes).toBe(0);
       expect(result.accessTokens).toBe(0);
+      expect(result.refreshTokens).toBe(0);
     });
   });
 });

--- a/src/test/modules/sessions/controller.test.ts
+++ b/src/test/modules/sessions/controller.test.ts
@@ -69,7 +69,8 @@ describe("sessions/controller", () => {
       expect(mockTransport.handleRequest).toHaveBeenCalled();
     });
 
-    it("throws when session not found", async () => {
+    it("throws when session not found for non-initialize request", async () => {
+      vi.mocked(isInitializeRequest).mockReturnValue(false);
       const req = createMockRequest({
         headers: { "mcp-session-id": "nonexistent" },
       });
@@ -82,7 +83,34 @@ describe("sessions/controller", () => {
       await expect(routeToSessionOrInitialize(req, res)).rejects.toThrow();
     });
 
-    it("creates a new session when stale sessionId is provided with an initialize request", async () => {
+    it("terminates old session and creates new one on initialize with stale sessionId", async () => {
+      vi.mocked(isInitializeRequest).mockReturnValue(true);
+      const mockTransport = { handleRequest: vi.fn() };
+      const existingSession = {
+        transport: { handleRequest: vi.fn() },
+        userId: "user-123",
+      };
+      const req = createMockRequest({
+        headers: { "mcp-session-id": "stale-session-id" },
+        body: { method: "initialize" },
+      });
+      const res = createMockResponse();
+      const sm = (
+        req as { _sessionManager: ReturnType<typeof createMockSessionManager> }
+      )._sessionManager;
+
+      sm.retrieveSession.mockResolvedValue(existingSession);
+      sm.terminateSession.mockResolvedValue(undefined);
+      sm.createSession.mockResolvedValue(mockTransport);
+
+      await routeToSessionOrInitialize(req, res);
+
+      expect(sm.terminateSession).toHaveBeenCalledWith("stale-session-id");
+      expect(sm.createSession).toHaveBeenCalledWith("user-123");
+      expect(mockTransport.handleRequest).toHaveBeenCalled();
+    });
+
+    it("creates new session on initialize with stale sessionId not in memory", async () => {
       vi.mocked(isInitializeRequest).mockReturnValue(true);
       const mockTransport = { handleRequest: vi.fn() };
       const req = createMockRequest({
@@ -90,23 +118,17 @@ describe("sessions/controller", () => {
         body: { method: "initialize" },
       });
       const res = createMockResponse();
+      const sm = (
+        req as { _sessionManager: ReturnType<typeof createMockSessionManager> }
+      )._sessionManager;
 
-      (
-        req as { _sessionManager: ReturnType<typeof createMockSessionManager> }
-      )._sessionManager.retrieveSession.mockResolvedValue(null);
-      (
-        req as { _sessionManager: ReturnType<typeof createMockSessionManager> }
-      )._sessionManager.createSession.mockResolvedValue(mockTransport);
+      sm.retrieveSession.mockResolvedValue(null);
+      sm.createSession.mockResolvedValue(mockTransport);
 
       await routeToSessionOrInitialize(req, res);
 
-      expect(
-        (
-          req as {
-            _sessionManager: ReturnType<typeof createMockSessionManager>;
-          }
-        )._sessionManager.createSession,
-      ).toHaveBeenCalledWith("user-123");
+      expect(sm.terminateSession).not.toHaveBeenCalled();
+      expect(sm.createSession).toHaveBeenCalledWith("user-123");
       expect(mockTransport.handleRequest).toHaveBeenCalled();
     });
 
@@ -128,7 +150,7 @@ describe("sessions/controller", () => {
       await expect(routeToSessionOrInitialize(req, res)).rejects.toThrow();
     });
 
-    it("creates session for initialize request", async () => {
+    it("creates session for initialize request without sessionId", async () => {
       vi.mocked(isInitializeRequest).mockReturnValue(true);
       const mockTransport = { handleRequest: vi.fn() };
       const req = createMockRequest({

--- a/src/test/modules/sessions/manager.test.ts
+++ b/src/test/modules/sessions/manager.test.ts
@@ -137,6 +137,7 @@ describe("SessionManager", () => {
         oauthStates: 1,
         authorizationCodes: 2,
         accessTokens: 3,
+        refreshTokens: 0,
       });
 
       await sessionManager.cleanupExpiredData();
@@ -155,6 +156,7 @@ describe("SessionManager", () => {
         oauthStates: 0,
         authorizationCodes: 0,
         accessTokens: 0,
+        refreshTokens: 0,
       });
 
       await sessionManager.cleanupExpiredData();


### PR DESCRIPTION
- Introduced a new table for storing refresh tokens with appropriate constraints and indexing.
- Updated the OAuth controller to handle refresh token grants, allowing users to obtain new access tokens using valid refresh tokens.
- Enhanced the schema to support refresh token requests and added corresponding service functions for creating and consuming refresh tokens.
- Updated tests to cover new refresh token functionality, ensuring robust validation and error handling.
- Adjusted constants to define refresh token expiration duration.

## Summary

<!-- Brief description of what this PR does -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] Other (describe below)

## Testing

<!-- How did you verify this works? Include any of the following: -->

**Video walkthrough (Loom, etc.):**
<!-- Paste link here -->

**Screenshots:**
<!-- Drag and drop images here -->

**Manual testing notes:**
<!-- Describe what you tested manually -->

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
